### PR TITLE
feat: set default ordered kinds as public

### DIFF
--- a/pkg/module/generator/ordered_resources.go
+++ b/pkg/module/generator/ordered_resources.go
@@ -10,8 +10,8 @@ import (
 
 type resource v1.Resource
 
-// defaultOrderedKinds provides the default order of Kubernetes resource kinds.
-var defaultOrderedKinds = []string{
+// DefaultOrderedKinds provides the default order of Kubernetes resource kinds.
+var DefaultOrderedKinds = []string{
 	"Namespace",
 	"ResourceQuota",
 	"StorageClass",
@@ -42,7 +42,7 @@ var defaultOrderedKinds = []string{
 // in a specified order.
 func OrderedResources(ctx context.Context, resources v1.Resources, orderedKinds []string) (v1.Resources, error) {
 	if len(orderedKinds) == 0 {
-		orderedKinds = defaultOrderedKinds
+		orderedKinds = DefaultOrderedKinds
 	}
 
 	if len(resources) == 0 {

--- a/pkg/module/generator/ordered_resources_test.go
+++ b/pkg/module/generator/ordered_resources_test.go
@@ -212,7 +212,7 @@ func TestFindDependKinds(t *testing.T) {
 		"PersistentVolume",
 		"PersistentVolumeClaim",
 	}
-	actual := r.findDependKinds(defaultOrderedKinds)
+	actual := r.findDependKinds(DefaultOrderedKinds)
 
 	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->
- `pkg/module/generator/ordered_resources.go`
- `pkg/module/generator/ordered_resources_test.go`
#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->
This PR sets the `defaultOrderedKinds` as public. 
#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
